### PR TITLE
Using File::Temp tmpnam() for dbname in tests

### DIFF
--- a/t/01-functional.t
+++ b/t/01-functional.t
@@ -17,8 +17,9 @@ use Test::Mojo;
 use DBD::SQLite;
 use DBI;
 use Try::Tiny;
+use File::Temp qw(tempfile);
 
-my $dbname = "/tmp/mojolicious-plugin-database-test.$$.db";
+my (undef, $dbname = tempfile("mojolicious-plugin-database-test.XXXXXX", OPEN => 0, UNLINK => 0);
 
 plugin 'database', { 
     'dsn'       => 'dbi:SQLite:dbname=' . $dbname,


### PR DESCRIPTION
Using core module File::Temp tmpnam() to genereate a name to use for the
test database. This allows the test to work in Linux and Windows (which
does not have a /tmp directory)
