### PR TITLE
Use File::Temp tmpnam for test database name

### DIFF
--- a/t/01-functional.t
+++ b/t/01-functional.t
@@ -17,9 +17,9 @@ use Test::Mojo;
 use DBD::SQLite;
 use DBI;
 use Try::Tiny;
-use File::Temp qw(tempfile);
+use File::Temp qw(tmpnam);
 
-my (undef, $dbname = tempfile("mojolicious-plugin-database-test.XXXXXX", OPEN => 0, UNLINK => 0);
+my $dbname = tmpnam();
 
 plugin 'database', { 
     'dsn'       => 'dbi:SQLite:dbname=' . $dbname,


### PR DESCRIPTION
Use the core module File::Temp tmpnam() to generate a temporary filename
for the test database. This works on Linux and Windows (which does not
have a /tmp directory)
